### PR TITLE
ci: add actionlint for GitHub Actions workflow linting

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -1,0 +1,22 @@
+name: GitHub Actions Lint
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["**"]
+
+permissions:
+  contents: read
+
+jobs:
+  actionlint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Run actionlint
+        uses: raven-actions/actionlint@205b530c5d9fa8f44ae9ed59f341a0db994aa6f8 # v2.1.2

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -35,6 +35,11 @@ repos:
       - id: ruff-format
         args: [--check]
 
+  - repo: https://github.com/rhysd/actionlint
+    rev: v1.7.11
+    hooks:
+      - id: actionlint
+
   - repo: local
     hooks:
       - id: pylint


### PR DESCRIPTION
## Summary
- Add `actionlint.yml` CI workflow using `raven-actions/actionlint` (SHA pinned)
- Add actionlint pre-commit hook for local workflow linting

## Test plan
- [x] `pre-commit run actionlint --all-files` passes