### PR TITLE
ci: add Docker build verification on PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,9 @@ env:
 jobs:
   docker-build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,32 @@
+name: CI
+
+on:
+  pull_request:
+    branches: ["main"]
+
+env:
+  BUILD_PLATFORMS: linux/amd64,linux/arm64
+
+jobs:
+  docker-build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+        with:
+          platforms: ${{ env.BUILD_PLATFORMS }}
+
+      - name: Build Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: ${{ env.BUILD_PLATFORMS }}
+          push: false
+          cache-from: type=gha
+          cache-to: type=gha,mode=max


### PR DESCRIPTION
## Summary
- PR에서 multi-platform Docker 빌드(amd64/arm64) 검증 CI 추가
- 릴리즈 전 빌드 실패 사전 감지

## Test plan
- [x] PR 생성 시 `docker-build` job 트리거 확인

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a CI workflow that runs on pull requests targeting main to build multi-architecture Docker images (linux/amd64 and linux/arm64).
  * Builds occur in an isolated job with cross-architecture support and build cache enabled to speed subsequent runs.
  * Images are built for verification during CI but are not pushed to a registry.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->