### PR TITLE
fix(docker): pin base image to Debian Bookworm

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,9 @@ env:
 jobs:
   docker-build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,32 @@
+name: CI
+
+on:
+  pull_request:
+    branches: ["main"]
+
+env:
+  BUILD_PLATFORMS: linux/amd64,linux/arm64
+
+jobs:
+  docker-build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+        with:
+          platforms: ${{ env.BUILD_PLATFORMS }}
+
+      - name: Build Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: ${{ env.BUILD_PLATFORMS }}
+          push: false
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ ARG UV_VERSION=0.10.10
 
 FROM ghcr.io/astral-sh/uv:${UV_VERSION} AS uv
 
-FROM python:${PYTHON_VERSION}-slim AS python-base
+FROM python:${PYTHON_VERSION}-slim-bookworm AS python-base
 
 ARG UID=1001
 ARG VERSION


### PR DESCRIPTION
## Summary
- `python:3.13.12-slim`이 Debian Trixie로 변경되면서 Playwright 의존성 설치 실패
- `slim-bookworm`으로 핀하여 해결

## Test plan
- [x] multi-platform Docker 빌드 성공 확인

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the base container image to use the newer Debian Bookworm variant, refreshing the underlying OS for improved compatibility and security updates across build and runtime images. No other build steps, environment settings, artifacts, or public APIs were changed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->