### PR TITLE
fix(docker): enable build cache with per-platform registry cache

### DIFF
--- a/.github/workflows/release_docker.yml
+++ b/.github/workflows/release_docker.yml
@@ -10,7 +10,6 @@ env:
   DOCKERHUB_REGISTRY: docker.io
   GHCR_REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
-  BUILD_PLATFORMS: linux/amd64,linux/arm64
 
 jobs:
   build:
@@ -18,6 +17,14 @@ jobs:
     permissions:
       contents: read
       packages: write
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            slug: linux-amd64
+          - platform: linux/arm64
+            slug: linux-arm64
 
     steps:
       - name: Checkout repository
@@ -28,8 +35,6 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
-        with:
-          platforms: ${{ env.BUILD_PLATFORMS }}
 
       - name: Login to ${{ env.DOCKERHUB_REGISTRY }}
         uses: docker/login-action@v4
@@ -61,17 +66,101 @@ jobs:
             # 1.2.3
             type=semver,pattern={{version}}
 
-      - name: Build and push
-        id: build-and-push
+      - name: Build and push by digest
+        id: build
         uses: docker/build-push-action@v6
         with:
           context: .
-          tags: ${{ steps.docker-meta.outputs.tags }}
           labels: ${{ steps.docker-meta.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-          platforms: ${{ env.BUILD_PLATFORMS }}
-          push: true
+          provenance: false
+          cache-from: type=registry,ref=${{ env.GHCR_REGISTRY }}/${{ env.IMAGE_NAME }}:cache-${{ matrix.slug }}
+          cache-to: type=registry,ref=${{ env.GHCR_REGISTRY }}/${{ env.IMAGE_NAME }}:cache-${{ matrix.slug }},mode=max
+          platforms: ${{ matrix.platform }}
+          outputs: type=image,"name=${{ env.DOCKERHUB_REGISTRY }}/${{ env.IMAGE_NAME }},${{ env.GHCR_REGISTRY }}/${{ env.IMAGE_NAME }}",push-by-digest=true,name-canonical=true,push=true
           build-args: |
             VERSION=${{ fromJSON(steps.docker-meta.outputs.json).labels['org.opencontainers.image.version'] }}
             REVISION=${{ fromJSON(steps.docker-meta.outputs.json).labels['org.opencontainers.image.revision'] }}
+
+      - name: Export digest
+        env:
+          DIGEST: ${{ steps.build.outputs.digest }}
+        run: |
+          mkdir -p "$RUNNER_TEMP/digests"
+          touch "$RUNNER_TEMP/digests/${DIGEST#sha256:}"
+
+      - name: Upload digest
+        uses: actions/upload-artifact@v4
+        with:
+          name: digests-${{ matrix.slug }}
+          path: ${{ runner.temp }}/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  merge:
+    runs-on: ubuntu-latest
+    needs: build
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Download digests
+        uses: actions/download-artifact@v4
+        with:
+          path: ${{ runner.temp }}/digests
+          pattern: digests-*
+          merge-multiple: true
+
+      - name: Login to ${{ env.DOCKERHUB_REGISTRY }}
+        uses: docker/login-action@v4
+        with:
+          registry: ${{ env.DOCKERHUB_REGISTRY }}
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Login to ${{ env.GHCR_REGISTRY }}
+        uses: docker/login-action@v4
+        with:
+          registry: ${{ env.GHCR_REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Extract Docker metadata
+        id: docker-meta
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            ${{ env.DOCKERHUB_REGISTRY }}/${{ env.IMAGE_NAME }}
+            ${{ env.GHCR_REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=edge
+            type=semver,pattern={{version}}
+
+      - name: Create manifest list and push
+        env:
+          DOCKER_META_JSON: ${{ steps.docker-meta.outputs.json }}
+          DOCKERHUB_IMAGE: ${{ env.DOCKERHUB_REGISTRY }}/${{ env.IMAGE_NAME }}
+          GHCR_IMAGE: ${{ env.GHCR_REGISTRY }}/${{ env.IMAGE_NAME }}
+        working-directory: ${{ runner.temp }}/digests
+        run: |
+          # Create and push manifest for Docker Hub
+          docker buildx imagetools create \
+            $(jq -cr '.tags | map(select(startswith("docker.io")) | "-t " + .) | join(" ")' <<< "$DOCKER_META_JSON") \
+            $(printf "${DOCKERHUB_IMAGE}@sha256:%s " *)
+
+          # Create and push manifest for GHCR
+          docker buildx imagetools create \
+            $(jq -cr '.tags | map(select(startswith("ghcr.io")) | "-t " + .) | join(" ")' <<< "$DOCKER_META_JSON") \
+            $(printf "${GHCR_IMAGE}@sha256:%s " *)
+
+      - name: Inspect images
+        env:
+          DOCKERHUB_IMAGE: ${{ env.DOCKERHUB_REGISTRY }}/${{ env.IMAGE_NAME }}
+          GHCR_IMAGE: ${{ env.GHCR_REGISTRY }}/${{ env.IMAGE_NAME }}
+          VERSION: ${{ steps.docker-meta.outputs.version }}
+        run: |
+          docker buildx imagetools inspect "${DOCKERHUB_IMAGE}:${VERSION}"
+          docker buildx imagetools inspect "${GHCR_IMAGE}:${VERSION}"

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,16 +5,6 @@ FROM ghcr.io/astral-sh/uv:${UV_VERSION} AS uv
 
 FROM python:${PYTHON_VERSION}-slim-bookworm AS python-base
 
-ARG UID=1001
-ARG VERSION
-ARG REVISION=""
-
-LABEL org.opencontainers.image.title="ridiwise" \
-    org.opencontainers.image.version="${VERSION}" \
-    org.opencontainers.image.url="https://github.com/bskim45/ridiwise" \
-    org.opencontainers.image.source="https://github.com/bskim45/ridiwise" \
-    org.opencontainers.image.authors="Bumsoo Kim <bskim45@gmail.com>"
-
 ENV PIP_NO_CACHE_DIR=off \
     PIP_DISABLE_PIP_VERSION_CHECK=on \
     PIP_DEFAULT_TIMEOUT=100 \
@@ -26,6 +16,7 @@ ENV PATH="$VENV_PATH/bin:$PATH"
 ENV PLAYWRIGHT_BROWSERS_PATH=/ms-playwright
 
 RUN useradd -m -u 1001 noroot
+
 
 FROM python-base AS build-venv
 ARG UV_VERSION
@@ -50,6 +41,15 @@ RUN playwright install --with-deps chromium \
 
 
 FROM build-playwright AS runtime
+
+ARG VERSION
+ARG REVISION=""
+
+LABEL org.opencontainers.image.title="ridiwise" \
+    org.opencontainers.image.version="${VERSION}" \
+    org.opencontainers.image.url="https://github.com/bskim45/ridiwise" \
+    org.opencontainers.image.source="https://github.com/bskim45/ridiwise" \
+    org.opencontainers.image.authors="Bumsoo Kim <bskim45@gmail.com>"
 
 WORKDIR /app
 


### PR DESCRIPTION
## Summary
- **Root cause**: `ARG VERSION/REVISION`이 `python-base` 스테이지에 선언되어 매 커밋마다 모든 하위 레이어(uv sync, playwright install)가 캐시 무효화됨
- `ARG/LABEL`을 최종 `runtime` 스테이지로 이동하여 중간 스테이지 캐시 보존
- 멀티플랫폼 빌드를 matrix strategy로 분리하고 GHCR registry cache 적용
- merge job 추가로 플랫폼별 digest를 멀티플랫폼 manifest로 합침

## Test plan
- [x] 캐시 없는 첫 빌드 성공 확인
- [x] 두 번째 빌드에서 모든 스텝 CACHED 확인 (amd64/arm64 모두 #12~#20)
- [x] 빌드 시간: arm64 기준 ~230s → ~37s (84% 단축)
- [x] merge job에서 Docker Hub/GHCR 멀티플랫폼 manifest 정상 생성 확인

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized Docker multi-platform build and release process for improved efficiency
  * Improved container image metadata organization

<!-- end of auto-generated comment: release notes by coderabbit.ai -->